### PR TITLE
Padronização da quantidade de cards na quinta seção 

### DIFF
--- a/src/components/Section5/index.tsx
+++ b/src/components/Section5/index.tsx
@@ -1,271 +1,271 @@
 import Image from "next/image"
 import SmallCardGlasses from "../SmallCardGlasses"
 
-function Section5 (){
+function Section5() {
     const AlanfOculos = [
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos1.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos1.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos2.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos2.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos3.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos3.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos4.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos4.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos5.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos5.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos6.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos6.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos7.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos7.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos8.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos8.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos9.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos9.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos10.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos10.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos11.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos11.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos12.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos12.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos13.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos13.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos14.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos14.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos15.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos15.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos16.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos16.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos17.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos17.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos18.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos18.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos19.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos19.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos20.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos20.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos21.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos21.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos22.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos22.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos23.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos23.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos24.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos24.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos25.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos25.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos26.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos26.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos27.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos27.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos28.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos28.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         },
 
         {
-            title:"Modelo DC",
-            linkImgGlasses:"/img/Section5/oculos29.svg",
-            modelo:"1111",
-            collection:"MODERN",
-            linkImgEnterprise:"/img/Section5/alanf-logo.svg"
+            title: "Modelo DC",
+            linkImgGlasses: "/img/Section5/oculos29.svg",
+            modelo: "1111",
+            collection: "MODERN",
+            linkImgEnterprise: "/img/Section5/alanf-logo.svg"
         }
     ];
 
-    return(
+    return (
         <>
-        <article id="Nanff" className="flex w-full flex-row mt-5">
-            <Image
-                src="/img/Section5/BannerSection5.svg"
-                alt=""
-                width={0}
-                height={0}
-                className="w-full"
-            />
-        </article>
+            <article id="Nanff" className="flex w-full flex-row mt-5">
+                <Image
+                    src="/img/Section5/BannerSection5.svg"
+                    alt=""
+                    width={0}
+                    height={0}
+                    className="w-full"
+                />
+            </article>
 
-        <main className="flex flex-col gap-5 mt-5 mb-10">
-            <div className="flex flex-col">
-                <div className="flex flex-col gap-5">
-                    <div className="flex flex-wrap gap-5 justify-center items-center">
-                        {AlanfOculos.map((oculos, index)=>(
-                            <SmallCardGlasses
-                            key={index}
-                            title={oculos.title}
-                            linkImgGlasses={oculos.linkImgGlasses}
-                            modelo={oculos.modelo}
-                            collection={oculos.collection}
-                            linkImgEnterprise={oculos.linkImgEnterprise}
-                            />
-                        ))}
+            <main className="flex flex-col items-center gap-5 mt-5 mb-10 px-4 sm:px-6 md:px-8">
+                <div className="flex flex-col w-full">
+                    <div className="flex flex-col gap-5">
+                        <div className="flex flex-wrap gap-5 justify-center max-w-screen-2xl mx-auto">
+                            {AlanfOculos.map((oculos, index) => (
+                                <SmallCardGlasses
+                                    key={index}
+                                    title={oculos.title}
+                                    linkImgGlasses={oculos.linkImgGlasses}
+                                    modelo={oculos.modelo}
+                                    collection={oculos.collection}
+                                    linkImgEnterprise={oculos.linkImgEnterprise}
+                                />
+                            ))}
+                        </div>
                     </div>
                 </div>
-            </div>
-        </main>
+            </main>
         </>
     )
 }


### PR DESCRIPTION
fix: correção da quinta seção que estava com a quantidade de cards por linha de forma dinamica e quando aumentava a tela ficava com mais de 5 cards (fora do padrao do figma) e agora está limitada a no máximo 5 em telas maiores